### PR TITLE
restrict allowed CORS origins

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,8 +18,10 @@ const accessLogStream = fs.createWriteStream(path.join(__dirname, LOG_FOLDER, 'a
 
 const filesRouter = require('./routes/files');
 
-// Allowed origins: any *.cancer.gov subdomain (https) and localhost on any port (dev)
-const ALLOWED_ORIGIN = /^https:\/\/[a-zA-Z0-9-]+\.cancer\.gov(:\d+)?$|^https?:\/\/localhost(:\d+)?$/;
+// Allowed origins: any *.cancer.gov subdomain (https), and localhost on any port in non-production environments
+const CANCER_GOV_ORIGIN = /^https:\/\/[a-zA-Z0-9-]+\.cancer\.gov(:\d+)?$/;
+const LOCALHOST_ORIGIN = /^https?:\/\/localhost(:\d+)?$/;
+const isProd = process.env.NODE_ENV === 'production';
 
 const app = express();
 if (config.mysqlSessionEnabled) app.use(createSession());
@@ -27,7 +29,8 @@ app.use(cors({
   origin: (origin, callback) => {
     // Allow server-to-server requests that have no Origin header
     if (!origin) return callback(null, true);
-    if (ALLOWED_ORIGIN.test(origin)) return callback(null, true);
+    if (CANCER_GOV_ORIGIN.test(origin)) return callback(null, true);
+    if (!isProd && LOCALHOST_ORIGIN.test(origin)) return callback(null, true);
     callback(null, false);
   }
 }));

--- a/app.js
+++ b/app.js
@@ -18,9 +18,19 @@ const accessLogStream = fs.createWriteStream(path.join(__dirname, LOG_FOLDER, 'a
 
 const filesRouter = require('./routes/files');
 
+// Allowed origins: any *.cancer.gov subdomain (https) and localhost on any port (dev)
+const ALLOWED_ORIGIN = /^https:\/\/[a-zA-Z0-9-]+\.cancer\.gov(:\d+)?$|^https?:\/\/localhost(:\d+)?$/;
+
 const app = express();
 if (config.mysqlSessionEnabled) app.use(createSession());
-app.use(cors());
+app.use(cors({
+  origin: (origin, callback) => {
+    // Allow server-to-server requests that have no Origin header
+    if (!origin) return callback(null, true);
+    if (ALLOWED_ORIGIN.test(origin)) return callback(null, true);
+    callback(null, false);
+  }
+}));
 
 // setup the logger
 app.use(logger('combined', { stream: accessLogStream }))

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "debug": "./node_modules/.bin/nodemon --inspect ./bin/www"
+    "debug": "./node_modules/.bin/nodemon --inspect ./bin/www",
+    "test": "jest",
+    "test:ci": "TZ=UTC CI=true jest --passWithNoTests --coverage --maxWorkers=2 --maxConcurrent=2"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.67.0",


### PR DESCRIPTION
[ICDC-4155](https://tracker.nci.nih.gov/browse/ICDC-4155)

- Resolves a LOW severity CORS configuration (CWE-16) where the /api/files/ endpoint was returning Access-Control-Allow-Origin: *, allowing any website to make cross-origin requests to the API.